### PR TITLE
feat: make TlsStream thread-safe

### DIFF
--- a/crates/rustfs-kafka/src/tls/mod.rs
+++ b/crates/rustfs-kafka/src/tls/mod.rs
@@ -64,7 +64,7 @@ impl TlsConfig {
 
 /// Trait for TLS stream implementations
 #[allow(dead_code)] // Methods may not be used in all configurations
-pub trait TlsStream: io::Read + io::Write + Send {
+pub trait TlsStream: io::Read + io::Write + Send + Sync {
     /// Returns true if this is a secured (TLS) connection
     fn is_secured(&self) -> bool;
 


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

add Sync to TlsStream to make it thread-safe. Got annoyed by warning when compiler said `future cannot be sent between threads safely`. This PR fixes it. 

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
